### PR TITLE
Use Travis CI to run flake8 tests to find syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 group: travis_latest
-dist: latest  # dist: >= xenial required for Python >= 3.7 (travis-ci/travis-ci#9069)
+dist: xenial  # dist: >= xenial required for Python >= 3.7 (travis-ci/travis-ci#9069)
 language: python
 python: 3.7
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+group: travis_latest
+dist: latest  # dist: >= xenial required for Python >= 3.7 (travis-ci/travis-ci#9069)
+language: python
+python: 3.7
+cache: pip
+install:
+  # - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - true  # add other tests here
+notifications:
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
The repo switch at  will need to be turned on at https://travis-ci.com/ColdGrub1384/Pyto

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree