### PR TITLE
Travis CI: Switch from default Linux to macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+# https://docs.travis-ci.com/user/reference/osx
+
 group: travis_latest
-dist: xenial  # dist: >= xenial required for Python >= 3.7 (travis-ci/travis-ci#9069)
-language: python
-python: 3.7
+os: osx
+osx_image: xcode10.1
+before_install:
+  - brew upgrade python
+  - pip install --upgrade pip
 cache: pip
 install:
   # - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@
 group: travis_latest
 os: osx
 osx_image: xcode10.1
+language: generic  # language: python is still not supported on os: osx
+cache: pip
 before_install:
   - brew upgrade python
   - pip install --upgrade pip
-cache: pip
 install:
   # - pip install -r requirements.txt
   - pip install flake8


### PR DESCRIPTION
This also provides access to iOS emulators as discussed in
* https://docs.travis-ci.com/user/reference/osx