### PR TITLE
Use sys.platform to identify the operating system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 before_script:
   - EXCLUDE=./.*,./Pyto_Mac/pip,./Pyto_Mac/PyObjC,./site-packages
   - flake8 . --count --exclude=${EXCLUDE} --select=E901,E999,F821,F822,F823  --show-source --statistics
-	- EXCLUDE=./.*,./Pyto*,./site-packages
+  - EXCLUDE=./.*,./Pyto*,./site-packages
   - flake8 . --count --exclude=${EXCLUDE} --max-complexity=10 --max-line-length=127 --show-source --statistics
   - flake8 --count --ignore=E111 "Pyto/Samples/Hello World.py" "Pyto/Samples/Open URL.py"
   - flake8 --count --ignore=E111 "Pyto/Samples/Pick File.py" "Pyto/Samples/Tint Color.py"

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,17 +40,17 @@
     
     <h3> Platforms </h3>
     <p>
-    Pyto supports iOS and macOS. If you want to check for platform, use the global <code>__platform__</code> variable.
+    Pyto supports iOS and macOS. If you want to check for platform, use the <code>sys.platform</code> variable.
     
     Example:
     
     <pre>
-    if __platform__ is iOS:
+    if sys.platform is 'ios':
         print("Running on iOS")
-    elif __platform__ is macOS:
+    elif sys.platform in ('darwin', 'macos'):
         print("Running on Mac")
     else:
-        print("Unknown platform")
+        print(f"Pyto is not compatible with {sys.platform}.")
     </pre>
     
     Scripts can be executed from the iOS app, from the Notification Center widget or from a process just for the script on macOS or a native iOS app built from a script. If you want to check from where the script is executed, check the <code>__host__</code> global variable.


### PR DESCRIPTION
* https://stackoverflow.com/questions/110362/how-can-i-find-the-current-os-in-python/110829
* https://docs.python.org/3/library/sys.html#sys.platform

The existing code will only work on Pyto platforms but this new version should work on all Python platforms.  The __sys.platform__ docs say it Mac OS X should be ___darwin___, not ___macos___.