### PR TITLE
Minor omission - pyto. prefix missing on line 18

### DIFF
--- a/site-packages/execthread.py
+++ b/site-packages/execthread.py
@@ -15,7 +15,7 @@
 import pyto
 from time import sleep
 
-__PyThread__ = PyThread
+__PyThread__ = pyto.PyThread
 
 def runSync(code):
     raise NameError("`runSync` was renamed to `run_sync`")


### PR DESCRIPTION
Import error without the proposed correction.