### PR TITLE
__ui_image_from_pil_image__ Assumed that the PIL image has a format, …

### DIFF
--- a/Lib/pyto_ui.py
+++ b/Lib/pyto_ui.py
@@ -4208,7 +4208,7 @@ def __ui_image_from_pil_image__(image):
         return None
 
     buffered = BytesIO()
-    image.save(buffered, format=image.format)
+    image.save(buffered, format='PNG')
     img_str = base64.b64encode(buffered.getvalue())
 
     data = __NSData__.alloc().initWithBase64EncodedString(img_str, options=0)


### PR DESCRIPTION
…which is not the case for generated images.

The proposed change uses PNG as the conversion format regardless of the original format of the image, if there was any. Hence the routine now works with generated images as well.