### PR TITLE
Fix return type annotation of location.get_location()

### DIFF
--- a/Lib/location.py
+++ b/Lib/location.py
@@ -40,11 +40,11 @@ def stop_updating():
     __PyLocationHelper__.stopUpdating()
 
 
-def get_location() -> Tuple[float]:
+def get_location() -> Tuple[float, float, float]:
     """
     Returns a tuple with current longitude, latitude and altitude.
 
-    :rtype: Tuple[float]
+    :rtype: Tuple[float, float, float]
     """
 
     return (float(__PyLocationHelper__.longitude), float(__PyLocationHelper__.latitude), float(__PyLocationHelper__.altitude))


### PR DESCRIPTION
`typing.Tuple` should contain a type for each element, or use ellipsis for a variable-length tuple of homogeneous type.

So, in this case `Tuple[float, float, float]` for longitude, latitude, altitude.

See docs here: https://docs.python.org/3/library/typing.html#typing.Tuple

---

This helps tools like mypy detecting errors in tuple unpacking - take the following example:

```python
from typing import Tuple


def get_location() -> Tuple[float]:
    return 1.23, 4.56, 7.89


lon, lat, alt = get_location()
```

Mypy output:

```
location_test.py:5: error: Incompatible return value type (got "Tuple[float, float, float]", expected "Tuple[float]")
location_test.py:8: error: Need more than 1 value to unpack (3 expected)
Found 2 errors in 1 file (checked 1 source file)
```