### PR TITLE
Correct the spelling of 'below' in View.insert_subview_bellow()

### DIFF
--- a/Lib/pyto_ui.py
+++ b/Lib/pyto_ui.py
@@ -2662,18 +2662,35 @@ class View:
         """
         Inserts the given view to the receiver's hierarchy bellow another given view.
 
+        .. warning::
+            Deprecated in favor of View.insert_subview_below().
+
         :param view: The view to insert.
         :param bellow_view: The view above the inserted view.
+
         """
 
-        self.__py_view__.insertSubview(view.__py_view__, bellow=bellow_view.__py_view__)
+        _warning = "View.insert_subview_bellow() is deprecated in favor of View.insert_subview_below()."
+        warnings.warn(_warning, DeprecationWarning)
+
+        self.__py_view__.insertSubview(view.__py_view__, below=bellow_view.__py_view__)
+
+    def insert_subview_below(self, view: View, below_view: View):
+        """
+        Inserts the given view to the receiver's hierarchy bellow another given view.
+
+        :param view: The view to insert.
+        :param below_view: The view above the inserted view.
+        """
+
+        self.__py_view__.insertSubview(view.__py_view__, below=below_view.__py_view__)
 
     def insert_subview_above(self, view: View, above_view: View):
         """
         Inserts the given view to the receiver's hierarchy above another given view.
 
         :param view: The view to insert.
-        :param above_view: The view bellow the inserted view.
+        :param above_view: The view below the inserted view.
         """
 
         self.__py_view__.insertSubview(view.__py_view__, above=above_view.__py_view__)

--- a/Pyto/Model/Python Bridging/UI/Views/PyView.swift
+++ b/Pyto/Model/Python Bridging/UI/Views/PyView.swift
@@ -650,8 +650,8 @@ import WebKit
     ///
     /// - Parameters:
     ///     - view: The view to be added.
-    ///     - subview: `view` will be placed bellow this view.
-    @objc public func insertSubview(_ view: PyView, bellow subview: PyView) {
+    ///     - subview: `view` will be placed below this view.
+    @objc public func insertSubview(_ view: PyView, below subview: PyView) {
         set {
             if !self.view.subviews.contains(view.view) {
                 self.view.insertSubview(view.view, belowSubview: subview.view)

--- a/Pyto/UI/SwiftUI Views/OnboardingView.swift
+++ b/Pyto/UI/SwiftUI Views/OnboardingView.swift
@@ -166,7 +166,7 @@ public struct OnboardingView: View {
                 pricingView
             })
             
-            Text("onboarding.twoPricesAvailable", comment: "The text bellow the purchase button")
+            Text("onboarding.twoPricesAvailable", comment: "The text below the purchase button")
             .font(.footnote)
             .frame(width: 200)
             .padding()

--- a/Pyto/UI/Views/ReplaceView.swift
+++ b/Pyto/UI/Views/ReplaceView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-/// The View placed bellow the find bar on the editor for replacing text.
+/// The View placed below the find bar on the editor for replacing text.
 class ReplaceView: UIView, UITextFieldDelegate {
     
     /// Code called for replacing all occurences in code. Parameter passed is a String to replace.

--- a/Pyto/de.lproj/Localizable.strings
+++ b/Pyto/de.lproj/Localizable.strings
@@ -390,7 +390,7 @@
 /* The button for choosing a pricing */
 "onboarding.purchase" = "Kauf";
 
-/* The text bellow the purchase button */
+/* The text below the purchase button */
 "onboarding.twoPricesAvailable" = "Zwei Preise verfügbar";
 
 /* 'Full' */

--- a/Pyto/en.lproj/Localizable.strings
+++ b/Pyto/en.lproj/Localizable.strings
@@ -70,7 +70,7 @@
 "creation.typeFolderName" = "Type the new folder's name";
 
 /* The message of the alert for adding an editor action. */
-"editorActionsTableViewController.createEditorActionAlertMessage" = "Type bellow the command to be executed. The first argument is the Python program to be executed. Type \"$SCRIPT\" for passing the edited script's path.\n\n Example:\npy2to3 -w $SCRIPT";
+"editorActionsTableViewController.createEditorActionAlertMessage" = "Type below the command to be executed. The first argument is the Python program to be executed. Type \"$SCRIPT\" for passing the edited script's path.\n\n Example:\npy2to3 -w $SCRIPT";
 
 /* The title of the alert for adding an editor action. */
 "editorActionsTableViewController.createEditorActionAlertTitle" = "Add script";
@@ -387,7 +387,7 @@
 /* The button for choosing a pricing */
 "onboarding.purchase" = "Purchase";
 
-/* The text bellow the purchase button */
+/* The text below the purchase button */
 "onboarding.twoPricesAvailable" = "Two prices available";
 
 /* 'Full' */

--- a/Pyto/es.lproj/Localizable.strings
+++ b/Pyto/es.lproj/Localizable.strings
@@ -387,7 +387,7 @@
 /* The button for choosing a pricing */
 "onboarding.purchase" = "Comprar";
 
-/* The text bellow the purchase button */
+/* The text below the purchase button */
 "onboarding.twoPricesAvailable" = "Dos precios disponibles";
 
 /* 'Full' */

--- a/Pyto/fr.lproj/Localizable.strings
+++ b/Pyto/fr.lproj/Localizable.strings
@@ -387,7 +387,7 @@
 /* The button for choosing a pricing */
 "onboarding.purchase" = "Acheter";
 
-/* The text bellow the purchase button */
+/* The text below the purchase button */
 "onboarding.twoPricesAvailable" = "Deux prix disponibles";
 
 /* 'Full' */


### PR DESCRIPTION
`View.insert_subview_bellow()` in `pyto_ui.py` has the word `below` spelt incorrectly as `bellow`, as well as having it misspelt in other places. 
I've corrected the spelling everywhere, except in that function itself to maintain backwards compatability. Instead I added a deprecation warning and a new method with the correct spelling.

I wasn't able to get the project to build (i think because I have a case sensitive file system) and I think documentation will need to be rebuilt, but it should get you most of the way there. 

Hopefully this makes it into the app because my OCD flairs up every time I type the function name with the double L.