### PR TITLE
Fix typechecking in widgets.Color.dynamic

### DIFF
--- a/Lib/widgets.py
+++ b/Lib/widgets.py
@@ -475,8 +475,8 @@ class Color:
         :rtype: widgets.Color
         """
 
-        check(light, "light", Color)
-        check(dark, "dark", Color)
+        check(light, "light", [Color])
+        check(dark, "dark", [Color])
 
         return cls(
             __PyColor__.colorWithLight(light.__py_color__, dark=dark.__py_color__)


### PR DESCRIPTION
Passing an array to `check` as it expects, fixes a `TypeError` when using `widgets.Color.dynamic`.

(I didn't see any guidelines for contributions, let me know if there's anything I should do other than just submitting a PR!)