### PR TITLE
setup.sh: Give pip multiple dependencies in a single run

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,13 +3,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 cd "$DIR"
 
-python3 -m pip install Cython
-python3 -m pip install numpy
-python3 -m pip install jinja2
-python3 -m pip install wheel
-python3 -m pip install sphinx
-python3 -m pip install sphinx-rtd-theme
-python3 -m pip install pbxproj
+python3 -m pip install --upgrade pip wheel
+python3 -m pip install Cython jinja2 numpy pbxproj sphinx sphinx-rtd-theme
 brew install zlib
 
 # Python


### PR DESCRIPTION
pip now has a real dependency resolver so give it multiple dependencies at once so the resolver can perform resolution.